### PR TITLE
UnionID

### DIFF
--- a/lib/omniauth/strategies/wechat.rb
+++ b/lib/omniauth/strategies/wechat.rb
@@ -50,6 +50,8 @@ module OmniAuth
             @raw_info = JSON.parse(response.body.gsub(/[\u0000-\u001f]+/, ''))
           else
             @raw_info = {"openid" => @uid }
+            @raw_info.merge!("unionid" => access_token["unionid"]) if access_token["unionid"]
+            @raw_info
           end
         end
       end


### PR DESCRIPTION
Store `unionid` in `raw_info` when the `scope` is `snsapi_base`.

Reference: http://mp.weixin.qq.com/wiki/17/c0f37d5704f0b64713d5d2c37b468d75.html#.E7.AC.AC.E4.BA.8C.E6.AD.A5.EF.BC.9A.E9.80.9A.E8.BF.87code.E6.8D.A2.E5.8F.96.E7.BD.91.E9.A1.B5.E6.8E.88.E6.9D.83access_token